### PR TITLE
Updating kubernetes yaml to work with newest versions

### DIFF
--- a/canary-deploy-app-v2-playbook/roles/common/files/app-v2-canary.yml
+++ b/canary-deploy-app-v2-playbook/roles/common/files/app-v2-canary.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: giropops-v2

--- a/canary-deploy-app-v2-playbook/roles/common/files/app-v2-canary.yml
+++ b/canary-deploy-app-v2-playbook/roles/common/files/app-v2-canary.yml
@@ -4,6 +4,9 @@ metadata:
   name: giropops-v2
 spec:
   replicas: 1
+  selector:
+    matchLabels: 
+      app: giropops
   template:
     metadata:
       labels:

--- a/deploy-app-v1-playbook/roles/common/files/app-v1.yml
+++ b/deploy-app-v1-playbook/roles/common/files/app-v1.yml
@@ -4,6 +4,9 @@ metadata:
   name: giropops-v1
 spec:
   replicas: 10
+  selector: 
+    matchLabels:
+      app: giropops
   template:
     metadata:
       labels:

--- a/deploy-app-v1-playbook/roles/common/files/app-v1.yml
+++ b/deploy-app-v1-playbook/roles/common/files/app-v1.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: giropops-v1

--- a/deploy-app-v2-playbook/roles/common/files/app-v1.yml
+++ b/deploy-app-v2-playbook/roles/common/files/app-v1.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: giropops-v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: giropops
   template:
     metadata:
       labels:

--- a/deploy-app-v2-playbook/roles/common/files/app-v2.yml
+++ b/deploy-app-v2-playbook/roles/common/files/app-v2.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: giropops-v2
 spec:
   replicas: 10
+  selector:
+    matchLabels:
+      app: giropops
   template:
     metadata:
       labels:


### PR DESCRIPTION
The apiVersion has been updated and now is also required to have a selector field in the Deployment yaml's